### PR TITLE
SP-160 Add another handler for invalid verification token

### DIFF
--- a/test/Yesod/Auth/SimpleSpec.hs
+++ b/test/Yesod/Auth/SimpleSpec.hs
@@ -94,6 +94,7 @@ spec = withApp $ do
         request $ do
           setMethod "POST"
           setUrl $ AuthR confirmR
+          addToken_ "form"
           byLabelExact "Password" "really difficult yesod password here"
         followRedirect >>=
           assertNotEq "path is not confirmation form" (Right (ur (AuthR confirmR)))


### PR DESCRIPTION
There is multiple types of tokens and one handler simply does not fit all cases. We want to return different content in registration and password reset scenarios.