### PR TITLE
Сhecking the email specified during registration

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,8 +10,10 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * `YesodAuthSimple` class methods:
   - `isConfirmationPending` to check if an email is waiting for confirmation
+  - `onEmailAlreadyExist` to specify an action if the email is already registered.
   - `confirmationEmailResentTemplate` to notify user that a confirmation email has been resent
 * Route `getConfirmationEmailResentR` to redirect user after the confirmation email has been resent
+* Functions `getError`, `setError`, `cleanError` added to export list
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,7 +13,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
   - `onEmailAlreadyExist` to specify an action if the email is already registered.
   - `confirmationEmailResentTemplate` to notify user that a confirmation email has been resent
 * Route `getConfirmationEmailResentR` to redirect user after the confirmation email has been resent
-* Functions `getError`, `setError`, `cleanError` added to export list
+* Functions `getError`, `setError`, `clearError` added to export list
 
 ### Changed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
-## 0.1.0 - 2022-05-02
+## 1.0.0 - 2022-05-04
 
 ### Added
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,22 @@
-# Revision history for yesod-auth-simple
+# Revision history for `yesod-auth-simple`
+
+This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
+
+## Unreleased
+
+## 0.1.0 - 2022-05-02
+
+### Added
+
+* `YesodAuthSimple` class methods:
+  - `isConfirmationPending` to check if an email is waiting for confirmation
+  - `confirmationEmailResentTemplate` to notify user that a confirmation email has been resent
+* Route `getConfirmationEmailResentR` to redirect user after the confirmation email has been resent
+
+### Changed
+
+* `postRegisterR` implementation logic. If you don't implement the new `YesodAuthSimple` methods,
+  it will work just like the old implementation
 
 ## 0.0.0  -- 2018-12-02
 

--- a/src/Yesod/Auth/Simple.hs
+++ b/src/Yesod/Auth/Simple.hs
@@ -207,7 +207,7 @@ class (YesodAuth a, PathPiece (AuthSimpleId a)) => YesodAuthSimple a where
 
   {- | Сheck if a registration confirmation is pending for the given email.
     
-    @since 0.1.0
+    @since 1.0.0
   -}
   isConfirmationPending :: Email -> AuthHandler a Bool
   isConfirmationPending _ = pure False
@@ -263,7 +263,7 @@ class (YesodAuth a, PathPiece (AuthSimpleId a)) => YesodAuthSimple a where
 
   {- | Template to notify user that a confirmation email has been resent.
 
-    @since 0.1.0
+    @since 1.0.0
   -}
   confirmationEmailResentTemplate :: WidgetFor a ()
   confirmationEmailResentTemplate = confirmationEmailSentTemplate
@@ -322,6 +322,7 @@ dispatch method path = case (method, path) of
   ("GET",  ["confirm"])                   -> sr getConfirmR
   ("POST", ["confirm"])                   -> sr postConfirmR
   ("GET",  ["confirmation-email-sent"])   -> sr getConfirmationEmailSentR
+  -- @since 1.0.0
   ("GET",  ["confirmation-email-resent"]) -> sr getConfirmationEmailResentR
   ("GET",  ["register-success"])          -> sr getRegisterSuccessR
   ("GET",  ["user-exists"])               -> sr getUserExistsR
@@ -583,7 +584,7 @@ getConfirmationEmailSentR = selectRep . provideRep . authLayout $ do
 
 {- | Confirmation to show after resending verification email.
 
-  @since 0.1.0
+  @since 1.0.0
 -}
 getConfirmationEmailResentR :: YesodAuthSimple a => AuthHandler a TypedContent
 getConfirmationEmailResentR = selectRep . provideRep . authLayout $ do

--- a/src/Yesod/Auth/Simple.hs
+++ b/src/Yesod/Auth/Simple.hs
@@ -62,7 +62,7 @@ module Yesod.Auth.Simple
     -- * Error handlers
   , getError
   , setError
-  , cleanError
+  , clearError
     -- * Misc
   , maxPasswordLength
     -- * Types

--- a/yesod-auth-simple.cabal
+++ b/yesod-auth-simple.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   yesod-auth-simple
-Version:                0.1.0
+Version:                1.0.0
 Author:                 Jezen Thomas <jezen@jezenthomas.com>
 Maintainer:             Jezen Thomas <jezen@jezenthomas.com>
 License:                BSD-3-Clause

--- a/yesod-auth-simple.cabal
+++ b/yesod-auth-simple.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   yesod-auth-simple
-Version:                0.0.0
+Version:                0.1.0
 Author:                 Jezen Thomas <jezen@jezenthomas.com>
 Maintainer:             Jezen Thomas <jezen@jezenthomas.com>
 License:                BSD-3-Clause


### PR DESCRIPTION
The following behavior has been added:

- We check If the user enters an active account’s email. If so the user is not able to continue to registration flow by displaying a warning message: “This email address is already in use. Please login to your existing account.”

- If the user enters an email address that is pending for confirmation, they will receive an activation link again and can be redirected to a separate page `confirmation-email-resent`.  For this you have to provide additional methods of `YesodAuthSimple` typeclass: `isConfirmationPending` and `confirmationEmailResentTemplate`. Otherwise, the previous behavior will be preserved.