### PR TITLE
Replace 'scrypt' with 'password'.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nix/nixpkgs.nix { inherit config; }
+{ pkgs ? import ./nix/nixpkgs.nix { inherit config;  }
 , config ? import ./nix/pkgconfig.nix { inherit compiler; }
 , compiler ? "ghc902"
 }:

--- a/nix/pkgconfig.nix
+++ b/nix/pkgconfig.nix
@@ -5,6 +5,7 @@
         "${compiler}" = pkgs.haskell.packages."${compiler}".override {
           overrides = hpNew: hpOld: rec {
             zxcvbn-hs = (hpNew.callPackage ./zxcvbn-hs.nix {});
+            password = (pkgs.haskell.lib.dontCheck hpOld.password);
           };
         };
       };

--- a/test/ExampleApp.hs
+++ b/test/ExampleApp.hs
@@ -18,6 +18,7 @@ module ExampleApp where
 
 import ClassyPrelude.Yesod
 import Data.Coerce (coerce)
+import qualified Data.Password.Scrypt as PSC
 import qualified Data.Vector as Vec
 import Database.Persist.Sql
 import Yesod.Auth
@@ -102,7 +103,7 @@ instance YesodAuthSimple App where
       _                   -> Nothing
 
   getUserPassword = do
-    let mkPass = EncryptedPass . encodeUtf8 . coerce . userPassword
+    let mkPass = PSC.PasswordHash . coerce . userPassword
     liftHandler . runDB . fmap mkPass . get404
 
   afterPasswordRoute = error "forced afterPasswordRoute"

--- a/test/Yesod/Auth/SimpleSpec.hs
+++ b/test/Yesod/Auth/SimpleSpec.hs
@@ -3,6 +3,7 @@
 
 module Yesod.Auth.SimpleSpec (spec) where
 
+import qualified Data.Password.Scrypt as PSC
 import qualified Data.Text as T
 import TestImport
 
@@ -115,9 +116,9 @@ spec = withApp $ do
     describe "with an email that is not unique" $
 
       it "automatically authenticates the existing user" $ do
-        encrypted <- liftIO $ encryptPassIO' $ Pass "strongpass"
+        encrypted <- liftIO $ PSC.hashPassword $ PSC.mkPassword "strongpass"
         let userEmail = Email  "user@example.com"
-            userPassword = Password . decodeUtf8 . getEncryptedPass $ encrypted
+	    userPassword = Password $ PSC.unPasswordHash $ encrypted
         runDB' . insert_ $ User{..}
 
         token <- runHandler $ getTestToken userEmail -- encryptRegisterToken userEmail

--- a/yesod-auth-simple.cabal
+++ b/yesod-auth-simple.cabal
@@ -44,7 +44,7 @@ Library
     , email-validate
     , http-types
     , memory
-    , scrypt
+    , password
     , text
     , time
     , wai
@@ -84,7 +84,7 @@ Common test-properties
     , monad-logger
     , persistent >= 2.8.2
     , persistent-sqlite
-    , scrypt
+    , password
     , text
     , time
     , vector


### PR DESCRIPTION
This shouldn't cause any problems with anything currently in `supercede`, but checking this would require more nix magic than a package override. Or, maybe my package override did work as intended and everything worked perfectly. I'm unsure. Needs a look at.