### PR TITLE
Add cryptonite package override.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import ./nix/nixpkgs.nix { inherit config;  }
+{ pkgs ? import ./nix/nixpkgs.nix { inherit config; }
 , config ? import ./nix/pkgconfig.nix { inherit compiler; }
 , compiler ? "ghc902"
 }:

--- a/nix/cryptonite.nix
+++ b/nix/cryptonite.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, fetchgit, lib, base,
+  basement, memory, tasty, tasty-hunit, 
+  tasty-kat, tasty-quickcheck
+}:
+mkDerivation {
+  pname = "cryptonite";
+  version = "0.30";
+  src = fetchgit {
+    url = "https://github.com/sethlivy/cryptonite";
+    rev = "5549034b3b6268bc57113753c730dad1368305db";
+    sha256 = null;
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [
+    base basement memory tasty tasty-hunit
+    tasty-kat tasty-quickcheck
+  ];
+  homepage = "https://github.com/haskell-crypto/crpytonite";
+  description = "lowlevel set of cryptographic primitives for haskell";
+  license = lib.licenses.mit;
+}

--- a/nix/pkgconfig.nix
+++ b/nix/pkgconfig.nix
@@ -6,6 +6,11 @@
           overrides = hpNew: hpOld: rec {
             zxcvbn-hs = (hpNew.callPackage ./zxcvbn-hs.nix {});
             password = (pkgs.haskell.lib.dontCheck hpOld.password);
+            cryptonite = 
+              if (builtins.currentSystem == "aarch64-darwin") then
+                (pkgs.haskell.lib.dontCheck (hpNew.callPackage ./cryptonite.nix {}))
+              else
+                (hpOld.cryptonite);
           };
         };
       };


### PR DESCRIPTION
Now we can build yesod-auth-simple on M1 Macs! With no emulation!