### PR TITLE
Add some re-exports.

### DIFF
--- a/src/Yesod/Auth/Simple.hs
+++ b/src/Yesod/Auth/Simple.hs
@@ -71,6 +71,11 @@ module Yesod.Auth.Simple
   , PW.Strength(..)
   , PasswordCheck(..)
   , PasswordStrength(..)
+    -- * Re-exports
+  , PSC.PasswordHash(..)
+  , PSC.hashPassword
+  , PSC.mkPassword
+  , PSC.Scrypt
   ) where
 
 import ClassyPrelude


### PR DESCRIPTION
This change re-exports some functions and types from `password`. These are equivalent to what was re-exported from `scrypt` in the previous version. 